### PR TITLE
LITE-28138 use a permanent media file link

### DIFF
--- a/connect_transformations/attachment_lookup/mixins.py
+++ b/connect_transformations/attachment_lookup/mixins.py
@@ -133,7 +133,7 @@ class AttachmentLookupWebAppMixin:
             StreamAttachment(
                 id=file['id'],
                 name=file['name'],
-                file=file['file'],
+                file=f'/public/v1/media/folders/streams_attachments/{stream_id}/files/{file["id"]}',
             )
             async for file in files.filter(query)
         ]

--- a/tests/webapp/test_attachment_lookup.py
+++ b/tests/webapp/test_attachment_lookup.py
@@ -61,11 +61,15 @@ async def test_get_excel_attachments(
     data = response.json()
     assert len(data) == 2
     assert {
-        'file': '/some/path/to/file.xlsx', 'id': 'MFL-0001', 'name': 'file.xlsx',
-    } in data
+        'file': '/public/v1/media/folders/streams_attachments/stream_id/files/MFL-0001',
+        'id': 'MFL-0001',
+        'name': 'file.xlsx',
+    } in data, data
     assert {
-        'id': 'MFL-0002', 'file': '/another/path/to/file-002.xlsx', 'name': 'file-002.xlsx',
-    } in data
+        'id': 'MFL-0002',
+        'file': '/public/v1/media/folders/streams_attachments/stream_id/files/MFL-0002',
+        'name': 'file-002.xlsx',
+    } in data, data
 
 
 def test_validate_attachment_lookup_invalid_data(test_client_factory):


### PR DESCRIPTION
use a permanent media file link because the name can be ch…anged