### PR TITLE
Fix currency conversion and vat rate transformations

### DIFF
--- a/README.md
+++ b/README.md
@@ -11,12 +11,15 @@ The current release provides the following transformations:
 * `Split columns`: This transformation function allows you to divide values of one column into separate columns, using regular expressions.
 * `Lookup CloudBlue subscription data`: This transformation function allows you to get the Cloudblue subscription data by the subscription ID or parameter value.
 * `Lookup CloudBlue product item`: This transformation function allows you to get the CloudBlue product item data by the product item ID or MPN.
-* `Convert currency`: This transformation function allows you to convert currency rates, using the https://exchangerate.host API.
+* `Convert currency`: This transformation function allows you to convert currency rates, using the https://apilayer.com/marketplace/exchangerates_data-api API.
 * `Formula`: This transformation function allows you to perform mathematical and logical operations on columns and context variables using the jq programming language.
 * `Delete rows by condition`: This transformation function allows you to delete rows that contain or do not contain a specific value(s).
 * `Lookup data from AirTable`: This transformation function allows you to populate data from AirTable by matching input column values with AirTable ones.
 * `Lookup data from Excel file attached to stream`: This transformation function allows you to populate data from the attached Excel file by matching input column values with the attached table values.
-* `Get standard VAT Rate for EU Country`: This transformation function is performed, using the latest rates from the https://exchangerate.host API. The input value must be either a two-letter country code defined in the ISO 3166-1 alpha-2 standard or country name. For example, ES or Spain.
+* `Get standard VAT Rate for EU Country`: This transformation function is performed, using the latest rates from the https://apilayer.com/marketplace/tax_data-api API. The input value must be either a two-letter country code defined in the ISO 3166-1 alpha-2 standard or country name. For example, ES or Spain.
+
+
+For currency convert and VAT rate environment variable EXCHANGE_API_KEY is required. Visit https://apilayer.com to choose plan and obtain API Key.
 
 Overall, Connect Standard Transformations Library is a valuable extension of the CloudBlue Connect platform that provides users with a powerful set of tools for managing and manipulating data. By providing pre-built transformations that can be easily configured and executed, Connect Standard Transformations Library streamlines the data transformation process and makes it easier for users to work with their data.
 

--- a/connect_transformations/currency_conversion/mixins.py
+++ b/connect_transformations/currency_conversion/mixins.py
@@ -115,7 +115,6 @@ class CurrencyConversionWebAppMixin:
         config: dict = Depends(get_config),
     ):
         try:
-            print(config)
             url = 'https://api.apilayer.com/exchangerates_data/symbols'
             async with httpx.AsyncClient(
                 transport=httpx.AsyncHTTPTransport(retries=3),
@@ -136,6 +135,5 @@ class CurrencyConversionWebAppMixin:
                     ),
                 )
             return currencies
-        except Exception as e:
-            print(e)
+        except Exception:
             return []

--- a/connect_transformations/currency_conversion/utils.py
+++ b/connect_transformations/currency_conversion/utils.py
@@ -75,9 +75,9 @@ def validate_currency_conversion(data):
     }
 
 
-def load_currency_rate(currency_from, currency_to):
+def load_currency_rate(currency_from, currency_to, api_key):
     try:
-        url = 'https://api.exchangerate.host/latest'
+        url = 'https://api.apilayer.com/exchangerates_data/latest'
         params = {
             'symbols': currency_to,
             'base': currency_from,
@@ -86,6 +86,7 @@ def load_currency_rate(currency_from, currency_to):
         response = requests.get(
             url,
             params=params,
+            headers={'apikey': api_key},
         )
         response.raise_for_status()
         data = response.json()

--- a/connect_transformations/formula/utils.py
+++ b/connect_transformations/formula/utils.py
@@ -37,7 +37,6 @@ def validate_formula(data):  # noqa: CCR001
         has_invalid_basic_structure(data)
         or does_not_contain_required_keys(data['columns'], ['output'])
     ):
-        print('error')
         return build_error_response('Invalid input data')
 
     if (

--- a/tests/transformations/test_currency_conversion.py
+++ b/tests/transformations/test_currency_conversion.py
@@ -19,7 +19,7 @@ def test_currency_conversion_first(mocker, responses):
     }
     responses.add(
         'GET',
-        'https://api.exchangerate.host/latest',
+        'https://api.apilayer.com/exchangerates_data/latest',
         match=[matchers.query_param_matcher(params)],
         json={
             'success': True,
@@ -27,7 +27,7 @@ def test_currency_conversion_first(mocker, responses):
         },
     )
     m = mocker.MagicMock()
-    app = StandardTransformationsApplication(m, m, m)
+    app = StandardTransformationsApplication(m, m, config={'EXCHANGE_API_KEY': 'API Key'})
     app.transformation_request = {
         'transformation': {
             'settings': [{
@@ -62,7 +62,7 @@ def test_currency_conversion_single_backward_compt(mocker, responses):
     }
     responses.add(
         'GET',
-        'https://api.exchangerate.host/latest',
+        'https://api.apilayer.com/exchangerates_data/latest',
         match=[matchers.query_param_matcher(params)],
         json={
             'success': True,
@@ -70,7 +70,7 @@ def test_currency_conversion_single_backward_compt(mocker, responses):
         },
     )
     m = mocker.MagicMock()
-    app = StandardTransformationsApplication(m, m, m)
+    app = StandardTransformationsApplication(m, m, {'EXCHANGE_API_KEY': 'API Key'})
     app.transformation_request = {
         'transformation': {
             'settings': {
@@ -105,7 +105,7 @@ def test_currency_conversion(mocker, responses):
     }
     responses.add(
         'GET',
-        'https://api.exchangerate.host/latest',
+        'https://api.apilayer.com/exchangerates_data/latest',
         match=[matchers.query_param_matcher(params)],
         json={
             'success': True,
@@ -113,7 +113,7 @@ def test_currency_conversion(mocker, responses):
         },
     )
     m = mocker.MagicMock()
-    app = StandardTransformationsApplication(m, m, m)
+    app = StandardTransformationsApplication(m, m, {'EXCHANGE_API_KEY': 'API Key'})
     app.transformation_request = {
         'transformation': {
             'settings': [{
@@ -148,12 +148,12 @@ def test_currency_conversion_first_http_error(mocker, responses):
     }
     responses.add(
         'GET',
-        'https://api.exchangerate.host/latest',
+        'https://api.apilayer.com/exchangerates_data/latest',
         match=[matchers.query_param_matcher(params)],
         status=500,
     )
     m = mocker.MagicMock()
-    app = StandardTransformationsApplication(m, m, m)
+    app = StandardTransformationsApplication(m, m, {'EXCHANGE_API_KEY': 'API Key'})
     app.transformation_request = {
         'transformation': {
             'settings': [{
@@ -170,46 +170,9 @@ def test_currency_conversion_first_http_error(mocker, responses):
     assert response.status == ResultType.FAIL
     assert (
         'An error occurred while requesting '
-        'https://api.exchangerate.host/latest with params'
+        'https://api.apilayer.com/exchangerates_data/latest with params'
         " {'symbols': 'EUR', 'base': 'USD'}"
     ) in response.output, response.output
-
-
-def test_currency_conversion_first_unexpected_response(mocker, responses):
-    params = {
-        'symbols': 'EUR',
-        'base': 'USD',
-    }
-    responses.add(
-        'GET',
-        'https://api.exchangerate.host/latest',
-        match=[matchers.query_param_matcher(params)],
-        json={
-            'success': False,
-            'result': None,
-        },
-    )
-    m = mocker.MagicMock()
-    app = StandardTransformationsApplication(m, m, m)
-    app.transformation_request = {
-        'transformation': {
-            'settings': [{
-                'from': {'column': 'COL1', 'currency': 'USD'},
-                'to': {'column': 'Price(Eur)', 'currency': 'EUR'},
-            }],
-            'columns': {
-                'input': [{'id': 'COL1', 'name': 'Price', 'nullable': False}],
-            },
-        },
-    }
-
-    response = app.currency_conversion({'Price': '22.5'})
-    assert response.status == ResultType.FAIL
-    assert (
-        'Unexpected response calling '
-        'https://api.exchangerate.host/latest with params'
-        " {'symbols': 'EUR', 'base': 'USD'}"
-    ) in response.output
 
 
 def test_currency_conversion_null_value(mocker):

--- a/tests/webapp/test_currency_conversion.py
+++ b/tests/webapp/test_currency_conversion.py
@@ -149,17 +149,20 @@ def test_get_available_rates(
 ):
     httpx_mock.add_response(
         method='GET',
-        url='https://api.exchangerate.host/symbols',
+        url='https://api.apilayer.com/exchangerates_data/symbols',
         json={
             'symbols': {
-                'EUR': {'code': 'EUR', 'description': 'Euro'},
-                'USD': {'code': 'USD', 'description': "United States Dollar's"},
+                'EUR': 'Euro',
+                'USD': 'United States Dollar',
             },
             'success': True,
         },
     )
     client = test_client_factory(TransformationsWebApplication)
-    response = client.get('/api/currency_conversion/currencies')
+    response = client.get(
+        '/api/currency_conversion/currencies',
+        config={'EXCHANGE_API_KEY': 'API Key'},
+    )
 
     assert response.status_code == 200
     data = response.json()
@@ -170,7 +173,7 @@ def test_get_available_rates(
         },
         {
             'code': 'USD',
-            'description': "United States Dollar's",
+            'description': 'United States Dollar',
         },
     ]
 
@@ -181,14 +184,17 @@ def test_get_available_rates_invalid_response(
 ):
     httpx_mock.add_response(
         method='GET',
-        url='https://api.exchangerate.host/symbols',
+        url='https://api.apilayer.com/exchangerates_data/symbols',
         json={
             'symbols': {},
             'success': False,
         },
     )
     client = test_client_factory(TransformationsWebApplication)
-    response = client.get('/api/currency_conversion/currencies')
+    response = client.get(
+        '/api/currency_conversion/currencies',
+        config={'EXCHANGE_API_KEY': 'API Key'},
+    )
 
     assert response.status_code == 200
     data = response.json()
@@ -201,11 +207,14 @@ def test_get_available_rates_invalid_status_code(
 ):
     httpx_mock.add_response(
         method='GET',
-        url='https://api.exchangerate.host/symbols',
+        url='https://api.apilayer.com/exchangerates_data/symbols',
         status_code=400,
     )
     client = test_client_factory(TransformationsWebApplication)
-    response = client.get('/api/currency_conversion/currencies')
+    response = client.get(
+        '/api/currency_conversion/currencies',
+        config={'EXCHANGE_API_KEY': 'API Key'},
+    )
 
     assert response.status_code == 200
     data = response.json()


### PR DESCRIPTION
Switched to [APILayer](https://apilayer.com/). It is almost identical to Exchangerate.host API, but supports HTTPS and the process of Sign up is easier and faster.

Currency exchange API: https://apilayer.com/marketplace/exchangerates_data-api#endpoints
VAT rate API: https://apilayer.com/marketplace/tax_data-api#endpoints

After sign up, subscribe to API (one key is generated for all subscribed services), put it as a secure environment variable EXCHANGE_API_KEY inside target environment and run extension as. usual.